### PR TITLE
fix: use builtin function as possible

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-common_copts = ['-msse4', '-mavx2', '-mbmi', '-mpclmul', '-mlzcnt']
+common_copts = ['-mavx2', '-mbmi', '-mpclmul', '-mlzcnt']
 sanitize_copts = ['-fsanitize=address,undefined', '-fsanitize-recover=address']
 
 cc_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-common_copts = ['-mavx2', '-mbmi', '-mpclmul', '-mlzcnt']
+common_copts = ['-mavx2', '-mbmi', '-mpclmul']
 sanitize_copts = ['-fsanitize=address,undefined', '-fsanitize-recover=address']
 
 cc_library(

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -36,12 +36,7 @@ sonic_force_inline int trailing_zeroes(uint64_t input_num) {
   // return (int)_tzcnt_u64(input_num);
   // but the generated code differs and might be less efficient?
   ////////
-#if sonic_has_builtin(__builtin_ctzll)
   return __builtin_ctzll(input_num);
-#else
-#error "!Not found __builtin_ctzll".
-  return 0;
-#endif
 }
 
 /* result might be undefined when input_num is zero */
@@ -55,32 +50,17 @@ sonic_force_inline uint64_t clear_lowest_bit(uint64_t input_num) {
 
 /* result might be undefined when input_num is zero */
 sonic_force_inline int leading_zeroes(uint64_t input_num) {
-#if sonic_has_builtin(__builtin_clzll)
   return __builtin_clzll(input_num);
-#else
-#error "!Not found __builtin_clzll".
-  return 0;
-#endif
 }
 
 sonic_force_inline long long int count_ones(uint64_t input_num) {
-#if sonic_has_builtin(__builtin_popcountll)
   return __builtin_popcountll(input_num);
-#else
-#error "!Not found __builtin_popcountll".
-  return 0;
-#endif
 }
 
 sonic_force_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                      uint64_t *result) {
-#if sonic_has_builtin(__builtin_uaddll_overflow)
   return __builtin_uaddll_overflow(
       value1, value2, reinterpret_cast<unsigned long long *>(result));
-#else
-#error "!Not found __builtin_uaddll_overflow".
-  return false;
-#endif
 }
 
 sonic_force_inline uint64_t prefix_xor(const uint64_t bitmask) {

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -36,7 +36,12 @@ sonic_force_inline int trailing_zeroes(uint64_t input_num) {
   // return (int)_tzcnt_u64(input_num);
   // but the generated code differs and might be less efficient?
   ////////
+#if sonic_has_builtin(__builtin_ctzll)
   return __builtin_ctzll(input_num);
+#else
+#error "!Not found __builtin_ctzll".
+  return 0;
+#endif
 }
 
 /* result might be undefined when input_num is zero */
@@ -44,24 +49,38 @@ sonic_force_inline uint64_t clear_lowest_bit(uint64_t input_num) {
 #if __BMI__
   return _blsr_u64(input_num);
 #else
-#error "BMI instruction set required. Missing option -mbmi ?"
-  return 0;
+  return input_num & (input_num - 1);
 #endif
 }
 
 /* result might be undefined when input_num is zero */
 sonic_force_inline int leading_zeroes(uint64_t input_num) {
-  return int(_lzcnt_u64(input_num));
+#if sonic_has_builtin(__builtin_clzll)
+  return __builtin_clzll(input_num);
+#else
+#error "!Not found __builtin_clzll".
+  return 0;
+#endif
 }
 
 sonic_force_inline long long int count_ones(uint64_t input_num) {
-  return _popcnt64(input_num);
+#if sonic_has_builtin(__builtin_popcountll)
+  return __builtin_popcountll(input_num);
+#else
+#error "!Not found __builtin_popcountll".
+  return 0;
+#endif
 }
 
 sonic_force_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                      uint64_t *result) {
+#if sonic_has_builtin(__builtin_uaddll_overflow)
   return __builtin_uaddll_overflow(
       value1, value2, reinterpret_cast<unsigned long long *>(result));
+#else
+#error "!Not found __builtin_uaddll_overflow".
+  return false;
+#endif
 }
 
 sonic_force_inline uint64_t prefix_xor(const uint64_t bitmask) {

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -45,4 +45,3 @@
 #include <cassert>
 #define sonic_assert(x) assert((x));
 #endif
-

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -26,12 +26,6 @@
 #define sonic_static_noinline static sonic_never_inline
 #define sonic_static_inline static sonic_force_inline
 
-#ifdef __has_builtin
-#define sonic_has_builtin(x) __has_builtin(x)
-#else
-#define sonic_has_builtin(x) (void)(x)
-#endif
-
 #ifdef SONIC_DEBUG
 #include <cassert>
 #include <cstdlib>

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -16,11 +16,26 @@
 
 #pragma once
 
+#define SONICJSON_PADDING 64
+
+#define sonic_likely(v) (__builtin_expect((v), 1))
+#define sonic_align(s) __attribute__((aligned(s)))
+#define sonic_unlikely(v) (__builtin_expect((v), 0))
+#define sonic_force_inline inline __attribute__((always_inline))
+#define sonic_never_inline inline __attribute__((noinline))
+#define sonic_static_noinline static sonic_never_inline
+#define sonic_static_inline static sonic_force_inline
+
+#ifdef __has_builtin
+#define sonic_has_builtin(x) __has_builtin(x)
+#else
+#define sonic_has_builtin(x) (void)(x)
+#endif
+
+#ifdef SONIC_DEBUG
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
-#include <string>
-
 #define sonic_specific_assert(expr)                                      \
   do {                                                                   \
     if (!(expr)) {                                                       \
@@ -29,25 +44,11 @@
       std::abort();                                                      \
     }                                                                    \
   } while (0);
-
-#define SONICJSON_PADDING 64
-#define sonic_likely(v) (__builtin_expect((v), 1))
-#define sonic_align(s) __attribute__((aligned(s)))
-#define sonic_unlikely(v) (__builtin_expect((v), 0))
-#define sonic_force_inline inline __attribute__((always_inline))
-#define sonic_never_inline inline __attribute__((noinline))
-#define sonic_static_noinline static sonic_never_inline
-
-#ifdef SONIC_DEBUG
 #define sonic_assert(x) sonic_specific_assert(x)
 #elif defined(NDEBUG)
 #define sonic_assert(x) (void)(x)
 #else
+#include <cassert>
 #define sonic_assert(x) assert((x));
 #endif
 
-#ifdef SONIC_NHEADONLY  // Not Headonly
-#define sonic_static_inline
-#else  // Headonly
-#define sonic_static_inline static sonic_force_inline
-#endif

--- a/tests/node_test.cpp
+++ b/tests/node_test.cpp
@@ -408,20 +408,23 @@ TYPED_TEST(NodeTest, EraseMember) {
   TestFixture::Add100Nodes(node1, a);
 
   for (int i = 9; i >= 0; --i) {
-    node1.EraseMember(node1.MemberBegin() + i * 10, node1.MemberBegin() + (i + 1) * 10);
+    node1.EraseMember(node1.MemberBegin() + i * 10,
+                      node1.MemberBegin() + (i + 1) * 10);
   }
   EXPECT_TRUE(node1.Empty());
 
   TestFixture::Add100Nodes(node1, a);
   using MemberIterator = typename NodeType::MemberIterator;
   for (int i = 0; i < 99; ++i) {
-    MemberIterator m = node1.EraseMember(node1.MemberBegin(), node1.MemberBegin() + 1);
+    MemberIterator m =
+        node1.EraseMember(node1.MemberBegin(), node1.MemberBegin() + 1);
     std::string expect_key = "key" + std::to_string(i + 1);
     EXPECT_TRUE(m->name == expect_key);
     EXPECT_TRUE(m->value.GetInt64() == i + 1);
   }
   {
-    MemberIterator m = node1.EraseMember(node1.MemberBegin(), node1.MemberBegin() + 1);
+    MemberIterator m =
+        node1.EraseMember(node1.MemberBegin(), node1.MemberBegin() + 1);
     EXPECT_TRUE(m == node1.MemberEnd());
   }
 }


### PR DESCRIPTION
# Main Change
 1. replace _lzcnt_u64 and _popcnt64 with builtin functions
 2. remove lzcnt instruction dependencies, the user can define out of the libraries if needed.
