### PR TITLE
fix: Set return value as Null when calling operator[] in DNode

### DIFF
--- a/include/sonic/dom/dynamicnode.h
+++ b/include/sonic/dom/dynamicnode.h
@@ -588,6 +588,7 @@ class DNode : public GenericNode<DNode, Allocator> {
       return m->value;
     }
     static DNode tmp{};
+    tmp.SetNull();
     return tmp;
   }
 

--- a/tests/node_test.cpp
+++ b/tests/node_test.cpp
@@ -314,6 +314,15 @@ TYPED_TEST(NodeTest, FindMember) {
     EXPECT_TRUE(obj["Unknown"].IsNull());
     EXPECT_TRUE(obj[std::string("False")].IsFalse());
   }
+
+  // Check return value always Null when provided key does'nt exist.
+  {
+    auto& value = obj["Unknown"];
+    EXPECT_TRUE(value.IsNull());
+    value.SetInt64(1);  // illed codes
+    auto& value1 = obj["Unknown"];
+    EXPECT_TRUE(value1.IsNull());
+  }
 }
 
 template <typename StringType, typename NodeType>


### PR DESCRIPTION
# Main changes:
- Ensure DNode::operator[] return value is Null when doesn't find key to avoid static variable has been changed.