### PR TITLE
opt: use customized memcpy

### DIFF
--- a/include/sonic/dom/handler.h
+++ b/include/sonic/dom/handler.h
@@ -21,6 +21,7 @@
 #include "sonic/dom/type.h"
 #include "sonic/string_view.h"
 #include "sonic/writebuffer.h"
+#include "sonic/internal/haswell.h"
 
 namespace sonic_json {
 
@@ -149,15 +150,11 @@ class SAXHandler {
     size_t old = obj.o.next.ofs;
     obj.setLength(pairs, kObject);
     if (pairs) {
-      // Note: shallow copy here, because resource pointer is owned by the node
-      // itself, likely move. But the node from begin to end will never call
-      // dctor, so, we don't need to set null at here. And this is diffrent from
-      // move.
       size_t size = pairs * 2 * sizeof(NodeType);
       void *mem = obj.template containerMalloc<typename NodeType::MemberNode>(
           pairs, *alloc_);
       obj.setChildren(mem);
-      std::memcpy((void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1),
+      internal::haswell::xmemcpy_16n((void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1),
                   size);
     } else {
       obj.setChildren(nullptr);
@@ -175,7 +172,7 @@ class SAXHandler {
       // As above note.
       size_t size = count * sizeof(NodeType);
       arr.setChildren(arr.template containerMalloc<NodeType>(count, *alloc_));
-      std::memcpy((void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1),
+      internal::haswell::xmemcpy_16n((void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1),
                   size);
     } else {
       arr.setChildren(nullptr);
@@ -245,7 +242,7 @@ class LazySAXHandler {
     if (count) {
       size_t size = count * sizeof(NodeType);
       arr.setChildren(arr.template containerMalloc<NodeType>(count, *alloc_));
-      std::memcpy((void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1),
+      internal::haswell::xmemcpy_16n((void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1),
                   size);
       stack_.Pop<NodeType>(count);
     } else {
@@ -262,7 +259,7 @@ class LazySAXHandler {
       void *mem = obj.template containerMalloc<typename NodeType::MemberNode>(
           pairs, *alloc_);
       obj.setChildren(mem);
-      std::memcpy((void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1),
+      internal::haswell::xmemcpy_16n((void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1),
                   size);
       stack_.Pop<NodeType>(pairs * 2);
     } else {

--- a/include/sonic/dom/handler.h
+++ b/include/sonic/dom/handler.h
@@ -151,10 +151,9 @@ class SAXHandler {
     size_t old = obj.o.next.ofs;
     obj.setLength(pairs, kObject);
     if (pairs) {
-      constexpr size_t CHUNK_SIZE = sizeof(MemberType);
       void *mem = obj.template containerMalloc<MemberType>(pairs, *alloc_);
       obj.setChildren(mem);
-      internal::haswell::xmemcpy<CHUNK_SIZE>(
+      internal::haswell::xmemcpy<sizeof(MemberType)>(
           (void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1), pairs);
     } else {
       obj.setChildren(nullptr);
@@ -169,9 +168,8 @@ class SAXHandler {
     size_t old = arr.o.next.ofs;
     arr.setLength(count, kArray);
     if (count) {
-      constexpr size_t CHUNK_SIZE = sizeof(NodeType);
       arr.setChildren(arr.template containerMalloc<NodeType>(count, *alloc_));
-      internal::haswell::xmemcpy<CHUNK_SIZE>(
+      internal::haswell::xmemcpy<sizeof(NodeType)>(
           (void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1), count);
     } else {
       arr.setChildren(nullptr);
@@ -240,9 +238,8 @@ class LazySAXHandler {
     NodeType &arr = *stack_.template Begin<NodeType>();
     arr.setLength(count, kArray);
     if (count) {
-      constexpr size_t CHUNK_SIZE = sizeof(NodeType);
       arr.setChildren(arr.template containerMalloc<NodeType>(count, *alloc_));
-      internal::haswell::xmemcpy<CHUNK_SIZE>(
+      internal::haswell::xmemcpy<sizeof(NodeType)>(
           (void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1), count);
       stack_.Pop<NodeType>(count);
     } else {
@@ -255,10 +252,9 @@ class LazySAXHandler {
     NodeType &obj = *stack_.template Begin<NodeType>();
     obj.setLength(pairs, kObject);
     if (pairs) {
-      constexpr size_t CHUNK_SIZE = sizeof(MemberType);
       void *mem = obj.template containerMalloc<MemberType>(pairs, *alloc_);
       obj.setChildren(mem);
-      internal::haswell::xmemcpy<CHUNK_SIZE>(
+      internal::haswell::xmemcpy<sizeof(MemberType)>(
           (void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1), pairs);
       stack_.Pop<MemberType>(pairs);
     } else {

--- a/include/sonic/dom/handler.h
+++ b/include/sonic/dom/handler.h
@@ -19,9 +19,9 @@
 #include <string>
 
 #include "sonic/dom/type.h"
+#include "sonic/internal/haswell.h"
 #include "sonic/string_view.h"
 #include "sonic/writebuffer.h"
-#include "sonic/internal/haswell.h"
 
 namespace sonic_json {
 
@@ -154,8 +154,8 @@ class SAXHandler {
       void *mem = obj.template containerMalloc<typename NodeType::MemberNode>(
           pairs, *alloc_);
       obj.setChildren(mem);
-      internal::haswell::xmemcpy_16n((void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1),
-                  size);
+      internal::haswell::xmemcpy_16n((void *)obj.getObjChildrenFirstUnsafe(),
+                                     (void *)(&obj + 1), size);
     } else {
       obj.setChildren(nullptr);
     }
@@ -172,8 +172,8 @@ class SAXHandler {
       // As above note.
       size_t size = count * sizeof(NodeType);
       arr.setChildren(arr.template containerMalloc<NodeType>(count, *alloc_));
-      internal::haswell::xmemcpy_16n((void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1),
-                  size);
+      internal::haswell::xmemcpy_16n((void *)arr.getArrChildrenFirstUnsafe(),
+                                     (void *)(&arr + 1), size);
     } else {
       arr.setChildren(nullptr);
     }
@@ -242,8 +242,8 @@ class LazySAXHandler {
     if (count) {
       size_t size = count * sizeof(NodeType);
       arr.setChildren(arr.template containerMalloc<NodeType>(count, *alloc_));
-      internal::haswell::xmemcpy_16n((void *)arr.getArrChildrenFirstUnsafe(), (void *)(&arr + 1),
-                  size);
+      internal::haswell::xmemcpy_16n((void *)arr.getArrChildrenFirstUnsafe(),
+                                     (void *)(&arr + 1), size);
       stack_.Pop<NodeType>(count);
     } else {
       arr.setChildren(nullptr);
@@ -259,8 +259,8 @@ class LazySAXHandler {
       void *mem = obj.template containerMalloc<typename NodeType::MemberNode>(
           pairs, *alloc_);
       obj.setChildren(mem);
-      internal::haswell::xmemcpy_16n((void *)obj.getObjChildrenFirstUnsafe(), (void *)(&obj + 1),
-                  size);
+      internal::haswell::xmemcpy_16n((void *)obj.getObjChildrenFirstUnsafe(),
+                                     (void *)(&obj + 1), size);
       stack_.Pop<NodeType>(pairs * 2);
     } else {
       obj.setChildren(nullptr);

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -58,9 +58,9 @@ sonic_force_inline long long int count_ones(uint64_t input_num) {
 }
 
 sonic_force_inline bool add_overflow(uint64_t value1, uint64_t value2,
-                                     uint64_t *result) {
+                                     uint64_t* result) {
   return __builtin_uaddll_overflow(
-      value1, value2, reinterpret_cast<unsigned long long *>(result));
+      value1, value2, reinterpret_cast<unsigned long long*>(result));
 }
 
 sonic_force_inline uint64_t prefix_xor(const uint64_t bitmask) {
@@ -77,13 +77,13 @@ sonic_force_inline uint64_t prefix_xor(const uint64_t bitmask) {
 #endif
 }
 
-sonic_force_inline bool is_ascii(const simd8x64<uint8_t> &input) {
+sonic_force_inline bool is_ascii(const simd8x64<uint8_t>& input) {
   return input.reduce_or().is_ascii();
 }
 
 template <size_t ChunkSize>
 sonic_force_inline void xmemcpy(void* dst_, const void* src_, size_t chunks) {
-  return std::memcpy(dst_, src_, chunks * ChunkSize);
+  std::memcpy(dst_, src_, chunks * ChunkSize);
 }
 
 template <>

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -105,14 +105,14 @@ sonic_force_inline void xmemcpy<32>(void* dst_, const void* src_,
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-      sonic_fallthrough;
     }
+    /* fall through */
     case 2: {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-      sonic_fallthrough;
     }
+    /* fall through */
     case 1: {
       simd256<uint8_t> s(src);
       s.store(dst);
@@ -139,14 +139,14 @@ sonic_force_inline void xmemcpy<16>(void* dst_, const void* src_,
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-      sonic_fallthrough;
     }
+    /* fall through */
     case 2: {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-      sonic_fallthrough;
     }
+    /* fall through */
     case 1: {
       simd256<uint8_t> s(src);
       s.store(dst);

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -16,9 +16,9 @@
 // Modifications are Copyright 2022 ByteDance Authors.
 
 #pragma once
-#include <x86intrin.h>
 
 #include "sonic/internal/simd.h"
+#include "sonic/macro.h"
 
 namespace sonic_json {
 namespace internal {
@@ -99,16 +99,19 @@ sonic_force_inline void xmemcpy_16n(void* dst_, const void* src_, size_t n) {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
+      sonic_fallthrough;
     } /* fallthrough; */
     case 2: {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
+      sonic_fallthrough;
     } /* fallthrough; */
     case 1: {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
+      sonic_fallthrough;
     } /* fallthrough; */
   }
   // has remained 16 bytes

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -81,7 +81,7 @@ sonic_force_inline bool is_ascii(const simd8x64<uint8_t> &input) {
   return input.reduce_or().is_ascii();
 }
 
-// xmemcpy_16n is only used for memcpy 16 * n
+// xmemcpy_16n is only used for memcpy N 16-bytes(n = N * 16).
 sonic_force_inline void xmemcpy_16n(void* dst_, const void* src_, size_t n) {
   uint8_t* dst = reinterpret_cast<uint8_t*>(dst_);
   const uint8_t* src = reinterpret_cast<const uint8_t*>(src_);
@@ -99,17 +99,17 @@ sonic_force_inline void xmemcpy_16n(void* dst_, const void* src_, size_t n) {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-    }
+    } /* fallthrough; */
     case 2: {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-    }
+    } /* fallthrough; */
     case 1: {
       simd256<uint8_t> s(src);
       s.store(dst);
       src += 32, dst += 32;
-    }
+    } /* fallthrough; */
   }
   // has remained 16 bytes
   if (n & 31) {

--- a/include/sonic/internal/haswell.h
+++ b/include/sonic/internal/haswell.h
@@ -82,7 +82,7 @@ sonic_force_inline bool is_ascii(const simd8x64<uint8_t> &input) {
 }
 
 // xmemcpy_16n is only used for memcpy 16 * n
-sonic_force_inline void xmemcpy_16n(void* dst_, const void*  src_, size_t n) {
+sonic_force_inline void xmemcpy_16n(void* dst_, const void* src_, size_t n) {
   uint8_t* dst = reinterpret_cast<uint8_t*>(dst_);
   const uint8_t* src = reinterpret_cast<const uint8_t*>(src_);
   size_t vn = n / 32;
@@ -95,12 +95,24 @@ sonic_force_inline void xmemcpy_16n(void* dst_, const void*  src_, size_t n) {
   }
   // has remained 1, 2, 3 * 32-bytes
   switch (vn & 3) {
-    case 3: { simd256<uint8_t> s(src); s.store(dst); src += 32, dst += 32; }
-    case 2: { simd256<uint8_t> s(src); s.store(dst); src += 32, dst += 32; }
-    case 1: { simd256<uint8_t> s(src); s.store(dst); src += 32, dst += 32; }
+    case 3: {
+      simd256<uint8_t> s(src);
+      s.store(dst);
+      src += 32, dst += 32;
+    }
+    case 2: {
+      simd256<uint8_t> s(src);
+      s.store(dst);
+      src += 32, dst += 32;
+    }
+    case 1: {
+      simd256<uint8_t> s(src);
+      s.store(dst);
+      src += 32, dst += 32;
+    }
   }
   // has remained 16 bytes
-  if (n & 31) { 
+  if (n & 31) {
     simd128<uint8_t> s(src);
     s.store(dst);
   }

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -30,8 +30,8 @@
 #ifndef __clang__
 #define sonic_fallthrough __attribute__((fallthrough))
 #else
-#define sonic_fallthrough 
-#endif 
+#define sonic_fallthrough
+#endif
 
 #endif
 

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -26,6 +26,15 @@
 #define sonic_static_noinline static sonic_never_inline
 #define sonic_static_inline static sonic_force_inline
 
+#ifndef sonic_fallthrough
+#ifndef __clang__
+#define sonic_fallthrough __attribute__((fallthrough))
+#else
+#define sonic_fallthrough 
+#endif 
+
+#endif
+
 #ifdef SONIC_DEBUG
 #include <cassert>
 #include <cstdlib>

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -25,7 +25,6 @@
 #define sonic_never_inline inline __attribute__((noinline))
 #define sonic_static_noinline static sonic_never_inline
 #define sonic_static_inline static sonic_force_inline
-#define sonic_fallthrough __attribute__((fallthrough))
 
 #ifdef SONIC_DEBUG
 #include <cassert>

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -25,15 +25,7 @@
 #define sonic_never_inline inline __attribute__((noinline))
 #define sonic_static_noinline static sonic_never_inline
 #define sonic_static_inline static sonic_force_inline
-
-#ifndef sonic_fallthrough
-#ifndef __clang__
 #define sonic_fallthrough __attribute__((fallthrough))
-#else
-#define sonic_fallthrough
-#endif
-
-#endif
 
 #ifdef SONIC_DEBUG
 #include <cassert>


### PR DESCRIPTION
# Main Changes

1. avoid function calls, std::memcpy may cause function calls
2. use loop unrolled simd memcpy

# Benchmarks
```
Benchmark                                Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------
lottie/Decode_SonicDyn                -0.0855         -0.0855        550518        503448        550519        503448
```