### PR TITLE
fix: support fallback for prefixxor

### DIFF
--- a/include/sonic/internal/arch/avx2/base.h
+++ b/include/sonic/internal/arch/avx2/base.h
@@ -75,8 +75,13 @@ sonic_force_inline uint64_t PrefixXor(const uint64_t bitmask) {
       _mm_clmulepi64_si128(_mm_set_epi64x(0ULL, bitmask), all_ones, 0);
   return _mm_cvtsi128_si64(result);
 #else
-#error "PCLMUL instruction set required. Missing option -mpclmul ?"
-  return 0;
+  bitmask ^= bitmask << 1;
+  bitmask ^= bitmask << 2;
+  bitmask ^= bitmask << 4;
+  bitmask ^= bitmask << 8;
+  bitmask ^= bitmask << 16;
+  bitmask ^= bitmask << 32;
+  return bitmask;
 #endif
 }
 

--- a/include/sonic/internal/arch/sse/base.h
+++ b/include/sonic/internal/arch/sse/base.h
@@ -70,8 +70,13 @@ sonic_force_inline uint64_t PrefixXor(const uint64_t bitmask) {
       _mm_clmulepi64_si128(_mm_set_epi64x(0ULL, bitmask), all_ones, 0);
   return _mm_cvtsi128_si64(result);
 #else
-#error "PCLMUL instruction set required. Missing option -mpclmul ?"
-  return 0;
+  bitmask ^= bitmask << 1;
+  bitmask ^= bitmask << 2;
+  bitmask ^= bitmask << 4;
+  bitmask ^= bitmask << 8;
+  bitmask ^= bitmask << 16;
+  bitmask ^= bitmask << 32;
+  return bitmask;
 #endif
 }
 

--- a/include/sonic/macro.h
+++ b/include/sonic/macro.h
@@ -51,7 +51,7 @@
 #define SONIC_STRINGIFY2(s) #s
 #endif
 
-#define SONIC_WESTMERE "pclmul,sse4.2"
+#define SONIC_WESTMERE "sse4.2"
 #define SONIC_HASWELL "avx2"
 #define SONIC_WESTMERE_STR(s) "arch=westmere"
 #define SONIC_HASWELL_STR(s) "arch=haswell"


### PR DESCRIPTION

Main Changes:
 to remove the dependent of palm instruction, so we support fallback logic in prefixxor function.