### PR TITLE
fix: to_bitmask return uint32_t to avoid sign extend int to uint64

### DIFF
--- a/include/sonic/internal/arch/avx2/simd.h
+++ b/include/sonic/internal/arch/avx2/simd.h
@@ -123,7 +123,9 @@ struct simd128<bool> : base128<bool> {
   // Splat constructor
   sonic_force_inline simd128<bool>(bool _value)
       : base128<bool>(splat(_value)) {}
-  sonic_force_inline uint32_t to_bitmask() const { return _mm_movemask_epi8(*this); }
+  sonic_force_inline uint64_t to_bitmask() const {
+    return (uint32_t)_mm_movemask_epi8(*this);
+  }
   // Override splat bool
   static sonic_force_inline simd128<bool> splat(bool _value) {
     return _mm_set1_epi8(uint8_t(-(!!_value)));
@@ -419,8 +421,9 @@ struct simd256<bool> : base256<bool> {
   // Splat constructor
   sonic_force_inline simd256<bool>(bool _value)
       : base256<bool>(splat(_value)) {}
-  sonic_force_inline uint32_t to_bitmask() const {
-    return _mm256_movemask_epi8(*this);
+  sonic_force_inline uint64_t to_bitmask() const {
+    // Zero extend int to uint64
+    return (uint32_t)_mm256_movemask_epi8(*this);
   }
   // Override splat bool
   static sonic_force_inline simd256<bool> splat(bool _value) {

--- a/include/sonic/internal/arch/avx2/simd.h
+++ b/include/sonic/internal/arch/avx2/simd.h
@@ -123,7 +123,7 @@ struct simd128<bool> : base128<bool> {
   // Splat constructor
   sonic_force_inline simd128<bool>(bool _value)
       : base128<bool>(splat(_value)) {}
-  sonic_force_inline int to_bitmask() const { return _mm_movemask_epi8(*this); }
+  sonic_force_inline uint32_t to_bitmask() const { return _mm_movemask_epi8(*this); }
   // Override splat bool
   static sonic_force_inline simd128<bool> splat(bool _value) {
     return _mm_set1_epi8(uint8_t(-(!!_value)));
@@ -419,7 +419,7 @@ struct simd256<bool> : base256<bool> {
   // Splat constructor
   sonic_force_inline simd256<bool>(bool _value)
       : base256<bool>(splat(_value)) {}
-  sonic_force_inline int to_bitmask() const {
+  sonic_force_inline uint32_t to_bitmask() const {
     return _mm256_movemask_epi8(*this);
   }
   // Override splat bool

--- a/include/sonic/internal/arch/common/x86_common/skip.inc.h
+++ b/include/sonic/internal/arch/common/x86_common/skip.inc.h
@@ -72,8 +72,8 @@ sonic_force_inline int SkipString(const uint8_t *data, size_t &pos,
   bool found = false;
   while (pos + VEC_LEN <= len) {
     const VecUint8Type v(data + pos);
-    bs_bits = static_cast<uint64_t>((v == '\\').to_bitmask());
-    quote_bits = static_cast<uint64_t>((v == '"').to_bitmask());
+    bs_bits = (v == '\\').to_bitmask();
+    quote_bits = (v == '"').to_bitmask();
 
     // maybe has escaped quotes
     if (((quote_bits - 1) & bs_bits) || prev_escaped) {

--- a/include/sonic/internal/arch/sse/simd.h
+++ b/include/sonic/internal/arch/sse/simd.h
@@ -116,7 +116,9 @@ struct simd128<bool> : base128<bool> {
   // Splat constructor
   sonic_force_inline simd128<bool>(bool _value)
       : base128<bool>(splat(_value)) {}
-  sonic_force_inline uint32_t to_bitmask() const { return _mm_movemask_epi8(*this); }
+  sonic_force_inline uint64_t to_bitmask() const {
+    return (uint32_t)_mm_movemask_epi8(*this);
+  }
   // Override splat bool
   static sonic_force_inline simd128<bool> splat(bool _value) {
     return _mm_set1_epi8(uint8_t(-(!!_value)));

--- a/include/sonic/internal/arch/sse/simd.h
+++ b/include/sonic/internal/arch/sse/simd.h
@@ -116,7 +116,7 @@ struct simd128<bool> : base128<bool> {
   // Splat constructor
   sonic_force_inline simd128<bool>(bool _value)
       : base128<bool>(splat(_value)) {}
-  sonic_force_inline int to_bitmask() const { return _mm_movemask_epi8(*this); }
+  sonic_force_inline uint32_t to_bitmask() const { return _mm_movemask_epi8(*this); }
   // Override splat bool
   static sonic_force_inline simd128<bool> splat(bool _value) {
     return _mm_set1_epi8(uint8_t(-(!!_value)));


### PR DESCRIPTION
There is a bug in `SkipString` that  caused by cast int to uint64.