### PR TITLE
Refactor GetByJsonPath and add batch processing for multiple JSON paths

### DIFF
--- a/include/sonic/internal/arch/x86_ifuncs/quote.h
+++ b/include/sonic/internal/arch/x86_ifuncs/quote.h
@@ -30,7 +30,7 @@ __attribute__((target("default"))) inline size_t parseStringInplace(
 }
 
 __attribute__((target("default"))) inline char *Quote(const char *, size_t,
-                                                      char *) {
+                                                      char *, bool) {
   // TODO static_assert(!!!"Not Implemented!");
   return 0;
 }
@@ -42,8 +42,9 @@ __attribute__((target(SONIC_WESTMERE))) inline size_t parseStringInplace(
 
 __attribute__((target(SONIC_WESTMERE))) inline char *Quote(const char *src,
                                                            size_t nb,
-                                                           char *dst) {
-  return sse::Quote(src, nb, dst);
+                                                           char *dst,
+                                                           bool escape_emoji) {
+  return sse::Quote(src, nb, dst, escape_emoji);
 }
 
 __attribute__((target(SONIC_HASWELL))) inline size_t parseStringInplace(
@@ -53,8 +54,9 @@ __attribute__((target(SONIC_HASWELL))) inline size_t parseStringInplace(
 
 __attribute__((target(SONIC_HASWELL))) inline char *Quote(const char *src,
                                                           size_t nb,
-                                                          char *dst) {
-  return avx2::Quote(src, nb, dst);
+                                                          char *dst,
+                                                          bool escape_emoji) {
+  return avx2::Quote(src, nb, dst, escape_emoji);
 }
 
 }  // namespace internal

--- a/tests/jsonpath_test.cpp
+++ b/tests/jsonpath_test.cpp
@@ -71,8 +71,7 @@ TEST(JsonPath, RootIdentifier) {
   // container
   TestOk(" [] ", "$", "[]");
   TestOk(" [\"😊\"] ", "$", "[\"\\uD83D\\uDE0A\"]");
-  TestOk(" {\"a\":  \"😊💎\"} ", "$",
-         "{\"a\":\"\\uD83D\\uDE0A\\uD83D\\uDC8E\"}");
+  TestOk(" {\"a\":  \"😊💎\"} ", "$", "{\"a\":\"\\uD83D\\uDE0A\\uD83D\\uDC8E\"}");
   TestOk(" {} ", "$", "{}");
   TestOk(R"( {"a":null} )", "$", R"({"a":null})");
   TestOk(R"( [[], {}, []] )", "$", R"([[],{},[]])");


### PR DESCRIPTION
- Refactored the `GetByJsonPath` function by extracting the core logic into a new `GetByJsonPathInternal` method to avoid redundant DOM parsing.
- Added `GetByJsonPaths`, a new function that supports querying multiple JSON paths in a single operation, which improves performance by parsing the JSON document only once.
- Updated tests:
  - Added `ValidBatchOK` utility to validate the results of batch processing.
  - Introduced new test cases (`WildCardBatch` and `BadBatch`) to ensure correct handling of valid and invalid JSON with multiple paths.
- Minor formatting improvements and inclusion of the `<algorithm>` header.