### PR TITLE
[fix] change uint to unsigned int

### DIFF
--- a/include/sonic/dom/genericnode.h
+++ b/include/sonic/dom/genericnode.h
@@ -1064,7 +1064,7 @@ class GenericNode {
     return std::numeric_limits<int64_t>::max();
   }
   sonic_force_inline uint64_t getUintMax() const {
-    return std::numeric_limits<uint>::max();
+    return std::numeric_limits<unsigned int>::max();
   }
 
  private:


### PR DESCRIPTION
`uint` is not always a typedef