### PR TITLE
fix: sax handler stack doesn't grow when it is full

### DIFF
--- a/include/sonic/dom/handler.h
+++ b/include/sonic/dom/handler.h
@@ -196,7 +196,12 @@ class SAXHandler {
       np_++;
       return true;
     } else {
-      return false;
+      cap_ += cap_;
+      st_ = static_cast<NodeType *>(
+          std::realloc((void *)(st_), sizeof(NodeType) * cap_));
+      if (!st_) return false;
+      np_++;
+      return true;
     }
   }
 

--- a/tests/document_test.cpp
+++ b/tests/document_test.cpp
@@ -320,6 +320,7 @@ TYPED_TEST(DocumentTest, Parse) {
       {"{[]}", &Document::IsNull, kError},
       {"{[}]", &Document::IsNull, kError},
       {"[[[[[[", &Document::IsNull, kError},
+      {"[[[[[[[[[[[[[[[[[[[[[[ \"\" ]", &Document::IsNull, kError},
       {"[NULL]", &Document::IsNull, kError},
       {R"([{"a":0})", &Document::IsNull, kError},
       {R"({"a":{"b":0})", &Document::IsNull, kError},


### PR DESCRIPTION
fix issue #111 
The stack of sax handler doesn't grow up when it is full and will cause coredump.