### PR TITLE
fix: keep emoji escape tail bounded

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -76,6 +76,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         with:
+          use_oidc: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           files: coverage.dat
           verbose: true
           fail_ci_if_error: true

--- a/include/sonic/internal/arch/common/quote_common.h
+++ b/include/sonic/internal/arch/common/quote_common.h
@@ -157,17 +157,17 @@ sonic_static_inline void DoEscape(const char*& src, char*& dst, size_t& nb) {
           // Not enough bytes for a 4-byte emoji, handle as raw char or error
           *dst++ = *src++;
           nb--;
-          continue;
+        } else {
+          // TODO: validate the utf8?
+          uint32_t unicode = (src[0] & 0x07) << 18 | (src[1] & 0x3f) << 12 |
+                             (src[2] & 0x3f) << 6 | (src[3] & 0x3f);
+          unicode -= 0x10000;
+          writeHex<UnicodeEscapeUpperCase>(0xD800 | ((unicode >> 10) & 0x3FF),
+                                           dst);
+          writeHex<UnicodeEscapeUpperCase>(0xDC00 | (unicode & 0x3FF), dst);
+          src += 4;
+          nb -= 4;
         }
-        // TODO: validate the utf8?
-        uint32_t unicode = (src[0] & 0x07) << 18 | (src[1] & 0x3f) << 12 |
-                           (src[2] & 0x3f) << 6 | (src[3] & 0x3f);
-        unicode -= 0x10000;
-        writeHex<UnicodeEscapeUpperCase>(0xD800 | ((unicode >> 10) & 0x3FF),
-                                         dst);
-        writeHex<UnicodeEscapeUpperCase>(0xDC00 | (unicode & 0x3FF), dst);
-        src += 4;
-        nb -= 4;
       }
     }
 

--- a/tests/quote_test.cpp
+++ b/tests/quote_test.cpp
@@ -40,6 +40,13 @@ void TestQuote(const std::string& input, const std::string& expect) {
   EXPECT_STREQ(buf.get(), expect.data());
 }
 
+void TestQuoteEscapeEmoji(const char* input, size_t n,
+                          const std::string& expect) {
+  auto buf = std::unique_ptr<char[]>(new char[(n + 2) * 12 + 32]);
+  char* end = Quote<SerializeFlags::kSerializeEscapeEmoji>(input, n, buf.get());
+  EXPECT_EQ(std::string(buf.get(), end - buf.get()), expect);
+}
+
 TEST(Quote, Normal) {
   std::vector<quoteTests> tests = {
       {"", "\"\""},
@@ -71,6 +78,13 @@ TEST(Quote, DiffSize) {
     std::string expect = "\"" + std::string(i * 2, '\\') + "\"";
     TestQuote(input, expect);
   }
+}
+
+TEST(Quote, EscapeEmojiStopsAtEndOfInvalidTail) {
+  const char input[] = {'\xfe', '\xff', '\xff'};
+  const char expect[] = {'"', '\xfe', '\xff', '\xff', '"'};
+  TestQuoteEscapeEmoji(input, sizeof(input),
+                       std::string(expect, sizeof(expect)));
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- stop emoji escaping at the end of a truncated or invalid UTF-8 tail
- add an ASAN-backed regression test for the bounded-input case
- authenticate same-repository pull request coverage uploads with Codecov OIDC while preserving tokenless uploads for forks

## Root cause

When fewer than four bytes remained, `DoEscape` copied one raw byte and used `continue`. That skipped the `nb == 0` termination check, allowing the loop to read beyond the input and eventually underflow the remaining length.

## Scope

- `include/sonic/internal/arch/common/quote_common.h`
- `tests/quote_test.cpp`
- `.github/workflows/test_coverage.yml`

No public API changes. The unrelated JSONPath, header self-containment, and broader CI changes from the earlier revision were removed.

## Validation

- regression test on the old implementation reproduced an AddressSanitizer `heap-buffer-overflow`
- `ASAN_OPTIONS=detect_leaks=0 ./build/tests/unittest '--gtest_filter=Quote.*' --gtest_brief=1` — 3/3 passed
- `ASAN_OPTIONS=detect_leaks=0 ./build/tests/unittest --gtest_brief=1` — 303/303 passed
- `git diff --check origin/master...HEAD`
- `actionlint .github/workflows/test_coverage.yml`
- GitHub Actions `Test Coverage` run `29555640052` — passed, including the Codecov OIDC upload
